### PR TITLE
use table_exists? to detect if migration table should be created to avoid SQLite3 error

### DIFF
--- a/lib/sinatra/sequel.rb
+++ b/lib/sinatra/sequel.rb
@@ -38,7 +38,7 @@ module Sinatra
   protected
 
     def create_migrations_table
-      database.create_table? :migrations do
+      unless database.table_exists? :migrations
         primary_key :id
         String :name, :null => false, :index => true
         timestamp :ran_at


### PR DESCRIPTION
use table_exists? to detect if migration table should be created to avoid SQLite3::SQLException: index migrations_name_index already exists
