### PR TITLE
Use Sinatra::Base#settings instead of Sinatra::Base#options

### DIFF
--- a/lib/sinatra/sequel.rb
+++ b/lib/sinatra/sequel.rb
@@ -5,7 +5,7 @@ require 'sequel'
 module Sinatra
   module SequelHelper
     def database
-      options.database
+      settings.database
     end
   end
 


### PR DESCRIPTION
Sinatra::Base#options is now deprecated.
